### PR TITLE
Fix UnicodeDecodeError in waliki.git.view.

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -267,6 +267,22 @@ class TestGit(TestCase):
         self.assertEqual(changes[0]['message'], 'commit all')
         self.assertEqual(changes[1]['message'], 'commit all')
 
+    def test_diff_with_space_and_tab(self):
+        self.page.raw = 'line with space\n'
+        Git().commit(self.page, message=u'one')
+        old = Git().last_version(self.page)
+
+        self.page.raw = '\tline with tab\n'
+        Git().commit(self.page, message=u'two')
+        new = Git().last_version(self.page)
+
+        response = self.client.get(reverse('waliki_diff', args=(self.page.slug, old, new,)))
+        old_content = response.context[0]['old_content']
+        new_content = response.context[0]['new_content']
+
+        self.assertEqual(old_content, u'line\u00a0with\u00a0space\n')
+        self.assertEqual(new_content, u'\u00a0\u00a0\u00a0\u00a0line\u00a0with\u00a0tab\n')
+
 
 class TestGitMove(TestCase):
 

--- a/waliki/git/views.py
+++ b/waliki/git/views.py
@@ -5,6 +5,7 @@ from django.http import Http404
 from django.core.management import call_command
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
+from django.utils.encoding import smart_text
 from django.utils.six import StringIO, text_type
 from django.views.decorators.csrf import csrf_exempt
 from waliki.models import Page
@@ -54,8 +55,10 @@ def diff(request, slug, old, new, raw=False):
     if raw:
         content = Git().diff(page, new, old)
         return HttpResponse(content, content_type='text/plain')
-    old_content = Git().version(page, old).replace('\t', '    ').replace(' ', '\xA0')
-    new_content = Git().version(page, new).replace('\t', '    ').replace(' ', '\xA0')
+    space = smart_text(b'\xc2\xa0', encoding='utf-8')  # non-breaking space character
+    tab = space * 4
+    old_content = Git().version(page, old).replace('\t', tab).replace(' ', space)
+    new_content = Git().version(page, new).replace('\t', tab).replace(' ', space)
     return render(request, 'waliki/diff.html', {'page': page,
                                                 'old_content': old_content,
                                                 'new_content': new_content,


### PR DESCRIPTION
Under some locale settings (e.g. zh_TW.UTF-8) the byte string
can't be properly decoded as unicode string and result in
UnicodeDecodeError.

This CL fix the problem by writing the byte string in UTF-8 and
decode them with django.utils.encoding.smart_text().