### PR TITLE
fixed roundoff error for whatchanged pagination

### DIFF
--- a/waliki/git/templates/waliki/history.html
+++ b/waliki/git/templates/waliki/history.html
@@ -34,18 +34,12 @@
             {% endfor %}
             </tbody>
         </table>
-{% if history|length > 10 %}
-
-<div class="form-group">
-    <button type="submit" class="btn disabled btn-default btn-sm" disabled="disabled">{% trans "Compare revisions" %}</button>
-    <a class="btn btn-default btn-sm" href="#top"><i class="icon-chevron-up"></i>{% trans "Back to top" %}</a>
-</div>
-{% endif %}
-</form>
-</div>
-</div>
-{% endblock content %}
-
+       <nav>
+         <ul class="pager">
+           <li class="previous {% if not prev %}disabled{% endif %}"><a href="{% if prev %}{% url 'waliki_history' page.slug prev %}{% else %}#{% endif %}">{% trans "Previous" %}</a></li>
+           <li class="next {% if not next %}disabled{% endif %}"><a href="{% if next %}{% url 'waliki_history' page.slug next %}{% else %}#{% endif %}">{% trans "Next" %}</a></li>
+         </ul>
+       </nav>
 
 {% block extra_script %}
 <script type="text/javascript">

--- a/waliki/git/templates/waliki/history.html
+++ b/waliki/git/templates/waliki/history.html
@@ -41,6 +41,8 @@
          </ul>
        </nav>
 
+{% endblock content %}
+
 {% block extra_script %}
 <script type="text/javascript">
 var $commits = $("input:checkbox[name=commit]");

--- a/waliki/git/urls.py
+++ b/waliki/git/urls.py
@@ -8,7 +8,8 @@ urlpatterns = patterns('waliki.git.views',
     url(r'^_whatchanged$', 'whatchanged', {'pag': '1'}, name='waliki_whatchanged'),       # noqa
 
     url(r'^_hooks/pull/(?P<remote>[a-zA-Z0-9]+)$', 'webhook_pull', name='waliki_webhook_pull'),
-    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/history$', 'history', name='waliki_history'),
+    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/history/(?P<pag>\d+)$', 'history', name='waliki_history'),
+    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/history/$', 'history', {'pag': '1'}, name='waliki_history'),
 
     url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/version/(?P<version>[0-9a-f\^]{4,40})/raw$', 'version', {'raw': True},
         name='waliki_version_raw'),

--- a/waliki/git/views.py
+++ b/waliki/git/views.py
@@ -69,9 +69,14 @@ def diff(request, slug, old, new, raw=False):
 
 def whatchanged(request, pag=1):
     changes = []
+    # The argument passed for pag might be a string, but we want to
+    # do calculations on it. So we must cast just to be sure.
     pag = int(pag or 1)
     skip = (pag - 1) * settings.WALIKI_PAGINATE_BY
     max_count = settings.WALIKI_PAGINATE_BY
+    # Git().total_commits() returns a unicode string
+    # but we want to do calculations on the number it represents,
+    # therefore, we cast
     total = int(Git().total_commits())
     for version in Git().whatchanged(skip, max_count):
         for path in version[-1]:
@@ -85,7 +90,7 @@ def whatchanged(request, pag=1):
 
     return render(request, 'waliki/whatchanged.html', {'changes': changes,
                                                        'prev': pag - 1 if pag > 1 else None,
-                                                       'next': pag + 1 if (total / settings.WALIKI_PAGINATE_BY) > pag else None})
+                                                       'next': pag + 1 if skip + max_count < total else None})
 
 
 @csrf_exempt


### PR DESCRIPTION
If the last page in Whatchanged does not contain exactly `settings.WALIKI_PAGINATE_BY` entries, then the previous page won't link to it. This change fixes that.
