### PR TITLE
Navbar Overlap Fix

### DIFF
--- a/waliki/templates/base.html
+++ b/waliki/templates/base.html
@@ -35,7 +35,7 @@
 
     <body>
         {% block navbar %}
-        <div class="navbar navbar-fixed-top navbar-default">
+        <div class="navbar navbar-default">
             <div class="container">
                 <div class="container">
                     <div class="row">

--- a/waliki/templates/base.html
+++ b/waliki/templates/base.html
@@ -37,7 +37,7 @@
         {% block navbar %}
         <div class="navbar navbar-default">
             <div class="container">
-                <div class="container">
+                <div class="navbar-header">
                     <div class="row">
                         <div class="col-sm-12 col-md-12"><div class="navbar-header"><a href="{% url 'waliki_home' %}" class="navbar-brand">{{ site_name|default:"Waliki" }}</a></div>
                             {% navbar_links %}


### PR DESCRIPTION
Removed class 'navbar-fixed-top' class which was overlapping the wiki content.