### PR TITLE
New optional setting to set a custom binary path to rst2pdf. resolve #62

### DIFF
--- a/docs/get_as_pdf.rst
+++ b/docs/get_as_pdf.rst
@@ -7,6 +7,16 @@ This a very simple plugin that leverages on rst2pdf_ to get a PDF version of a p
 
 It registers a new :ref:`extra_page_action view <write_plugin>` in the dropdown menu as *"Get as PDF"*. For obvious reasons, it only appears in reStructuredText pages.
 
+Get it working on python 3
+--------------------------
+
+rst2pdf_ is a python2 software, so if we are running Waliki with python3 is not possible to run rst2pdf inside the virtualenv.
+To get it working you simply have to install rst2pdf as an OS package (apt-get install rst2pdf or pacman -S python2-rst2pdf) and then add 
+`WALIKI_PDF_RST2PDF_BIN` to your waliki settings file detailing the rst2pdf binary path. For example::
+
+    WALIKI_PDF_RST2PDF_BIN='/usr/bin/rst2pdf'
+
+
 .. tip:: It should be trivial to write new plugins that
          add support to other converter tools like any ``rst2*``
          or Pandoc_ to convert from markdown.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -92,6 +92,11 @@ You can override any settings in your project's :file:`settings.py` file
     As the title is not part of the file content but stored in the database, it should be given
     to rst2pdf. Default is ``False``
 
+.. confval:: WALIKI_PDF_RST2PDF_BIN
+
+    Apply if :ref:`PDF plugin <pdf>` is installed.
+
+    A custom binary path to rst2pdf. E.g. '/usr/bin/rst2pdf'
 
 .. confval:: WALIKI_CODEMIRROR_SETTINGS
 

--- a/waliki/pdf/views.py
+++ b/waliki/pdf/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from waliki.models import Page
 from waliki.utils import send_file
 from waliki.settings import WALIKI_PDF_INCLUDE_TITLE
+from waliki.settings import WALIKI_PDF_RST2PDF_BIN
 from waliki.acl import permission_required
 
 
@@ -21,6 +22,8 @@ def pdf(request, slug):
             infile = infile.name
     else:
         infile = page.abspath
+    if WALIKI_PDF_RST2PDF_BIN:
+        rst2pdf._path = WALIKI_PDF_RST2PDF_BIN.encode('utf8')
     rst2pdf(infile, o=outfile)
     filename = page.title.replace('/', '-').replace('..', '-')
     return send_file(outfile, filename="%s.pdf" % filename)

--- a/waliki/settings.py
+++ b/waliki/settings.py
@@ -80,6 +80,9 @@ WALIKI_MARKUPS_SETTINGS = _get_markup_settings(getattr(settings, 'WALIKI_MARKUPS
 # get as txt
 WALIKI_PDF_INCLUDE_TITLE = getattr(settings, 'WALIKI_PDF_INCLUDE_TITLE', False)
 
+# custom rst2pdf binary path. You should set it on python3.
+WALIKI_PDF_RST2PDF_BIN = getattr(settings, 'WALIKI_PDF_RST2PDF_BIN', False)
+
 WALIKI_CODEMIRROR_SETTINGS = getattr(settings, 'WALIKI_CODEMIRROR_SETTINGS',
                                      {'lineNumbers': False, 'theme': 'monokai', 'autofocus': True})
 


### PR DESCRIPTION
A workaround to get rst2pdf working on python3