### PR TITLE
96 attachment no

### DIFF
--- a/waliki/attachments/models.py
+++ b/waliki/attachments/models.py
@@ -15,6 +15,7 @@ from waliki.settings import WALIKI_UPLOAD_TO
 class Attachment(models.Model):
     page = models.ForeignKey(Page, related_name='attachments')
     file = models.FileField(upload_to=WALIKI_UPLOAD_TO, max_length=300)
+    filename = models.CharField(max_length=300)
 
     class Meta:
         verbose_name = _("Attachment")
@@ -24,7 +25,7 @@ class Attachment(models.Model):
     	return os.path.basename(self.file.name)
 
     def get_absolute_url(self):
-        return reverse('waliki_attachment_file', args=(self.page.slug, self.id, text_type(self)))
+        return reverse('waliki_attachment_file', args=(self.page.slug, text_type(self.file)))
 
 
 # @receiver(pre_delete, sender=Attachment)

--- a/waliki/attachments/models.py
+++ b/waliki/attachments/models.py
@@ -22,10 +22,10 @@ class Attachment(models.Model):
         verbose_name_plural = _("Attachments")
 
     def __str__(self):
-    	return os.path.basename(self.file.name)
+        return os.path.basename(self.file.name)
 
     def get_absolute_url(self):
-        return reverse('waliki_attachment_file', args=(self.page.slug, text_type(self.file)))
+        return reverse('waliki_attachment_file', args=(self.page.slug, text_type(self)))
 
 
 # @receiver(pre_delete, sender=Attachment)

--- a/waliki/attachments/urls.py
+++ b/waliki/attachments/urls.py
@@ -4,8 +4,8 @@ from waliki.settings import WALIKI_SLUG_PATTERN
 urlpatterns = patterns('waliki.attachments.views',
     url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/attachments$', 'attachments',
         name='waliki_attachments'),
-    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/attachments/(?P<attachment_id>\d+)/delete$',
+    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/attachments/(?P<attachment_id_or_filename>.*)/delete$',
         'delete_attachment', name='waliki_delete_attachment'),
-    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/attachment/(?P<attachment_id>\d+)/(?P<filename>.*)$',
+    url(r'^(?P<slug>' + WALIKI_SLUG_PATTERN + ')/attachment/((?P<attachment_id>\d+)/)?(?P<filename>.*)$',
         'get_file',   name='waliki_attachment_file')
 )

--- a/waliki/attachments/views.py
+++ b/waliki/attachments/views.py
@@ -13,30 +13,33 @@ from .models import Attachment
 
 @permission_required('change_page')
 def attachments(request, slug):
-	last_attached = None
-	page = get_object_or_404(Page, slug=slug)
-	if request.method == 'POST' and 'attach' in request.FILES:
-		last_attached = request.FILES['attach']
-		Attachment.objects.create(file=last_attached, page=page)
-		messages.success(request, '"%s" was attached succesfully to /%s' % (last_attached.name, page.slug))
-	return render(request, 'waliki/attachments.html', {'page': page})
+    last_attached = None
+    page = get_object_or_404(Page, slug=slug)
+    if request.method == 'POST' and 'attach' in request.FILES:
+        last_attached = request.FILES['attach']
+        Attachment.objects.create(file=last_attached, page=page)
+        messages.success(request, '"%s" was attached succesfully to /%s' % (last_attached.name, page.slug))
+    return render(request, 'waliki/attachments.html', {'page': page})
 
 
 @permission_required('delete_page')
-def delete_attachment(request, slug, attachment_id):
-	attachment = get_object_or_404(Attachment, id=attachment_id, page__slug=slug)
-	name = text_type(attachment)
-	if request.is_ajax() and request.method in ('POST', 'DELETE'):
-		attachment.delete()
-		return HttpResponse(json.dumps({'removed': name}), content_type="application/json")
-	return HttpResponse(json.dumps({'removed': None}), content_type="application/json")
+def delete_attachment(request, slug, attachment_id_or_filename):
+    if attachment_id_or_filename.isnumeric():
+        attachment = get_object_or_404(Attachment, id=attachment_id_or_filename, page__slug=slug)
+    else:
+        attachment = get_object_or_404(Attachment, filename=attachment_id_or_filename, page__slug=slug)
+    name = text_type(attachment)
+    if request.is_ajax() and request.method in ('POST', 'DELETE'):
+        attachment.delete()
+        return HttpResponse(json.dumps({'removed': name}), content_type="application/json")
+    return HttpResponse(json.dumps({'removed': None}), content_type="application/json")
 
 
 @permission_required('view_page', raise_exception=True)
-def get_file(request, slug, attachment_id, filename):
-	attachment = get_object_or_404(Attachment, id=attachment_id, page__slug=slug)
-	as_attachment = ((not imghdr.what(attachment.file.path) and 'embed' not in request.GET)
-					  or 'as_attachment' in request.GET)
-	# ref https://github.com/johnsensible/django-sendfile
-	return sendfile(request, attachment.file.path,
-					attachment=as_attachment, attachment_filename=text_type(attachment))
+def get_file(request, slug, attachment_id=None, filename=None):
+    attachment = get_object_or_404(Attachment, filename=filename, page__slug=slug)
+    as_attachment = ((not imghdr.what(attachment.file.path) and 'embed' not in request.GET)
+                      or 'as_attachment' in request.GET)
+    # ref https://github.com/johnsensible/django-sendfile
+    return sendfile(request, attachment.file.path,
+                    attachment=as_attachment, attachment_filename=text_type(attachment))

--- a/waliki/attachments/views.py
+++ b/waliki/attachments/views.py
@@ -17,7 +17,7 @@ def attachments(request, slug):
     page = get_object_or_404(Page, slug=slug)
     if request.method == 'POST' and 'attach' in request.FILES:
         last_attached = request.FILES['attach']
-        Attachment.objects.create(file=last_attached, page=page)
+        Attachment.objects.create(file=last_attached, page=page, filename=last_attached.name)
         messages.success(request, '"%s" was attached succesfully to /%s' % (last_attached.name, page.slug))
     return render(request, 'waliki/attachments.html', {'page': page})
 

--- a/waliki/management/commands/sync_waliki.py
+++ b/waliki/management/commands/sync_waliki.py
@@ -58,9 +58,9 @@ class Command(BaseCommand):
                     if not os.path.isfile(os.path.join(path, filename)):
                         continue
                     file = WALIKI_UPLOAD_TO(FakeAttachment(page), filename)
-                    if page.attachments.filter(file=filename):
+                    if page.attachments.filter(file=file):
                         continue
-                    attachment = Attachment.objects.create(page=page, file=file)
+                    attachment = Attachment.objects.create(page=page, file=file, filename=filename)
                     self.stdout.write('Created attachment %s for %s' % (attachment, page.slug))
 
             for attachment in Attachment.objects.all():


### PR DESCRIPTION
Regarding issue #96. Fixed a few errors and now it seems to work -- you can link to attachments without using the attachment id. 