### PR TITLE
Run git with output to pipe instead of virtual terminal.

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -10,6 +10,7 @@ from waliki.git import Git
 from waliki.settings import WALIKI_DATA_DIR, WALIKI_COMMITTER_EMAIL, WALIKI_COMMITTER_NAME
 from .factories import PageFactory
 
+git = git.bake("--no-pager", _tty_out=False)
 
 class TestGit(TestCase):
 

--- a/waliki/git/__init__.py
+++ b/waliki/git/__init__.py
@@ -10,7 +10,7 @@ from sh import git, ErrorReturnCode, Command
 from collections import namedtuple
 
 
-git = git.bake("--no-pager")
+git = git.bake("--no-pager", _tty_out=False)
 Commit = namedtuple('Commit', ['hash', 'author_name', 'author_email', 'subject', 'date', 'date_relative', 'paths', 'diff'])
 
 


### PR DESCRIPTION
Default SELinux policy (at least, on Fedora) doesn't allow processes running from Apache HTTP server to create virtual terminals.
By default, `sh` Python module runs processes with output to virtual terminal.
This is not needed for git, so it's better to explicitly make it write its output to a pipe instead of virtual terminal.

Also, `--no-pager` option and output through a pipe added to git tests.