### PR TITLE
Run more commands with output to pipe instead of virtual terminal.

### DIFF
--- a/tests/test_git_webhook.py
+++ b/tests/test_git_webhook.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 from sh import git
+git = git.bake("--no-pager", _tty_out=False)
 
 
 class TestGitWebhook(TestCase):

--- a/tests/test_slides.py
+++ b/tests/test_slides.py
@@ -14,6 +14,7 @@ from waliki.forms import MovePageForm, DeleteForm
 from .factories import PageFactory, UserFactory, ACLRuleFactory
 try:
     from sh import hovercraft
+    hovercraft = hovercraft.bake(_tty_out=False)
 except ImportError:
     hovercraft = False
 

--- a/waliki/management/commands/moin_migration_cleanup.py
+++ b/waliki/management/commands/moin_migration_cleanup.py
@@ -12,6 +12,8 @@ except ImportError:
 
 try:
     from sh import pandoc, echo
+    pandoc = pandoc.bake(_tty_out=False)
+    echo = echo.bake(_tty_out=False)
 except ImportError:
     pandoc = None
 

--- a/waliki/pdf/views.py
+++ b/waliki/pdf/views.py
@@ -7,6 +7,8 @@ from waliki.settings import WALIKI_PDF_INCLUDE_TITLE
 from waliki.settings import WALIKI_PDF_RST2PDF_BIN
 from waliki.acl import permission_required
 
+rst2pdf = rst2pdf.bake(_tty_out=False)
+
 
 @permission_required('view_page')
 def pdf(request, slug):

--- a/waliki/slides/views.py
+++ b/waliki/slides/views.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 try:
     from sh import hovercraft
+    hovercraft = hovercraft.bake(_tty_out=False)
 except ImportError:
     hovercraft = None
 


### PR DESCRIPTION
This change makes all remaining (hopefully) commands invoked using `sh` module run with output to a pipe.

Default SELinux policy (at least, on Fedora) doesn't allow processes running from Apache HTTP server to create virtual terminals.

By default, `sh` Python module runs processes with output to virtual terminal. This is not needed for git and other commands, so it's better to explicitly make them write their output to a pipe instead of virtual terminal.
