### PR TITLE
Don't strip PageForm's raw field in Django 1.9.

### DIFF
--- a/waliki/forms.py
+++ b/waliki/forms.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from .models import Page
@@ -62,7 +63,11 @@ class NewPageForm(forms.ModelForm):
 
 
 class PageForm(forms.ModelForm):
-    raw = forms.CharField(label="", widget=forms.Textarea)
+    raw = forms.CharField(label="", widget=forms.Textarea,
+                          **({'strip': False}
+                                 if VERSION[0] > 1 or
+                                    VERSION[0] == 1 and VERSION[1] >= 9
+                              else {}))
     # Translators: log message
     message = forms.CharField(label=_('Log message'), max_length=200, required=False)
     extra_data = forms.CharField(widget=forms.HiddenInput, required=False)


### PR DESCRIPTION
`CharField`'s behaviour changed in Django 1.9: now field's value is stripped off leading and trailing whitespaces by default.

To prevent this, additional `strip=False` parameter is needed, but only if Django version is >= 1.9.

Tested with Django 1.9 and Django 1.9.