### PR TITLE
Fixes for new markups and Django

### DIFF
--- a/waliki/_markups.py
+++ b/waliki/_markups.py
@@ -42,15 +42,17 @@ class ReStructuredTextMarkup(ReStructuredTextMarkupBase):
 
         self.kwargs = kwargs
 
-    def publish_parts(self, text):
-        if 'rest_parts' in self._cache:
-            return self._cache['rest_parts']
-        parts = self._publish_parts(text, source_path=self.filename,
-                                    settings_overrides=self.overrides,
-                                    reader=self.reader, **self.kwargs)
-        if self._enable_cache:
-            self._cache['rest_parts'] = parts
-        return parts
+        def override_publish_parts(publish_parts):
+            def publish_parts_new(*args, **kwargs):
+                kwargs['reader'] = self.reader
+                kwargs.update(self.kwargs)
+                parts = publish_parts(*args, **kwargs)
+                parts['html_body'] = parts['body']
+                parts['stylesheet'] = ''
+                return parts
+            return publish_parts_new
+
+        self._publish_parts = override_publish_parts(self._publish_parts)
 
     def get_document_body(self, text):
         html = super(ReStructuredTextMarkup, self).get_document_body(text)

--- a/waliki/_markups.py
+++ b/waliki/_markups.py
@@ -15,9 +15,14 @@ class MarkdownMarkup(MarkdownMarkupBase):
 
 
     def __init__(self, filename=None, extensions=None, extension_configs=None):
+        self.extensions_ = extensions
+        self.extension_configs_ = extension_configs
         super(MarkdownMarkup, self).__init__(filename)
+
+    def _apply_extensions(self):
+        super(MarkdownMarkup, self)._apply_extensions()
         self.md.set_output_format('html5')
-        self.md.registerExtensions(extensions, extension_configs)
+        self.md.registerExtensions(self.extensions_, self.extension_configs_)
 
 
 class ReStructuredTextMarkup(ReStructuredTextMarkupBase):

--- a/waliki/forms.py
+++ b/waliki/forms.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from .models import Page
@@ -62,7 +63,11 @@ class NewPageForm(forms.ModelForm):
 
 
 class PageForm(forms.ModelForm):
-    raw = forms.CharField(label="", widget=forms.Textarea)
+    raw = forms.CharField(label="", widget=forms.Textarea,
+                          **({'strip': False}
+                                 if VERSION[0] > 1 or
+                                    VERSION[0] == 1 and VERSION[1] >= 9
+                              else {}))
     # Translators: log message
     message = forms.CharField(label=_('Log message'), max_length=200, required=False)
     extra_data = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/waliki/settings.py
+++ b/waliki/settings.py
@@ -48,10 +48,10 @@ def _get_markup_settings(user_settings):
                     'writer_name': 'html5',
                     },
                 'Markdown': {
-                    'extensions': ['wikilinks', 'headerid'],
+                    'extensions': ['wikilinks', 'toc'],
                     'extension_configs': {
                         'wikilinks': {'build_url': get_url},
-                        'headerid': {'level': 2},
+                        'toc': {'baselevel': 2},
                     }
                 }
             }


### PR DESCRIPTION
This pull request contains changes needed for Waliki to pass all tests with `Django` 1.9 and `markups` 2.0.

* Provide `strip=False` to `PageForm`'s `raw` field for `Django` >= 1.9.
* Use `markdown`'s `toc` extension instead of deprecated `headerid`.
* Move setting `markdown` extensions and output format to the method that creates `Markdown` instance.
* Pass additional parameters to `ReStructuredTextMarkup` the way that works in `markdown` 2.0.

These changes were tested with:
* `Django` 1.8.15 and `markups` 1.0.1 with Python 2.7.11 and 3.4.2.
* `Django` 1.9.12 and `markups` 2.0.0 with Python 2.7.12 and 3.5.2.