### PR TITLE
Make permissions given by user or group actually work.

### DIFF
--- a/waliki/acl.py
+++ b/waliki/acl.py
@@ -35,7 +35,7 @@ def check_perms(perms, user, slug, raise_exception=False):
         return True
 
     # First check if the user has the permission (even anon users)
-    if user.has_perms(perms):
+    if user.has_perms(['waliki.%s' % p for p in perms]):
         return True
     # In case the 403 handler should be called raise the exception
     if raise_exception:


### PR DESCRIPTION
As per [Django documentation](https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.models.User.has_perms) the method `has_perms` expects a list of strings of the format `<app label>.<permission codename>`.

Wiki permissions given directly to the user or a group he's part of won't work without this change.