### PR TITLE
Move page form doesn't show the current slug

### DIFF
--- a/waliki/views.py
+++ b/waliki/views.py
@@ -72,7 +72,7 @@ def detail(request, slug, raw=False):
 def move(request, slug):
     page = get_object_or_404(Page, slug=slug)
     data = request.POST if request.method == 'POST' else None
-    form = MovePageForm(data, instance=page)
+    form = MovePageForm(data, instance=page, initial={'slug': page.slug})
     if request.method == 'POST' and form.is_valid():
         new_slug = form.cleaned_data['slug']
 


### PR DESCRIPTION
What's the motivation for not showing the current slug, but instead an empty field on the MovePageForm (achieved by `exclude = ('slug',)`)?

Doesn't that just make it more tedious to use? If I just want to fix a typo in the slug I'll have to at a minimum copy & paste it from the URL...