### PR TITLE
Downloading an attachment doesn't work if there's another one an overlapping suffix

### DIFF
--- a/waliki/attachments/views.py
+++ b/waliki/attachments/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import imghdr
+import posixpath
 from django.shortcuts import render, get_object_or_404
 from django.contrib import messages
 from django.utils.six import text_type
@@ -27,7 +28,7 @@ def delete_attachment(request, slug, attachment_id_or_filename):
     if attachment_id_or_filename.isnumeric():
         attachment = get_object_or_404(Attachment, id=attachment_id_or_filename, page__slug=slug)
     else:
-        attachment = get_object_or_404(Attachment, file__endswith=attachment_id_or_filename, page__slug=slug)
+        attachment = get_object_or_404(Attachment, file__endswith='%s%s' % (posixpath.sep, attachment_id_or_filename), page__slug=slug)
     name = text_type(attachment)
     if request.is_ajax() and request.method in ('POST', 'DELETE'):
         attachment.delete()
@@ -37,7 +38,7 @@ def delete_attachment(request, slug, attachment_id_or_filename):
 
 @permission_required('view_page', raise_exception=True)
 def get_file(request, slug, attachment_id=None, filename=None):
-    attachment = get_object_or_404(Attachment, file__endswith=filename, page__slug=slug)
+    attachment = get_object_or_404(Attachment, file__endswith='%s%s' % (posixpath.sep, filename), page__slug=slug)
     as_attachment = ((not imghdr.what(attachment.file.path) and 'embed' not in request.GET)
                       or 'as_attachment' in request.GET)
     # ref https://github.com/johnsensible/django-sendfile


### PR DESCRIPTION
The view functions in `waliki.attachments` use `endswith` to get the database object corresponding to a attachment. If one uploads two attachments with - for example - the names `a.pdf` and `aa.pdf` and then tries to download the former there's an error because there are now two entries in the database where the filename ends with `a.pdf`.