### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
    :target: https://readthedocs.org/projects/waliki/?badge=latest
    :alt: Documentation Status
 
-.. image:: https://pypip.in/wheel/waliki/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/waliki.svg
     :target: https://pypi.python.org/pypi/waliki/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20waliki))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `waliki`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.