### PR TITLE
First edit validation fix

### DIFF
--- a/waliki/static/js/waliki_editor.js
+++ b/waliki/static/js/waliki_editor.js
@@ -1,4 +1,5 @@
 var editor = CodeMirror.fromTextArea(document.getElementById("id_raw"), cm_settings);
+$('#id_raw').removeAttr('required');
 
 $(document.body).on('click', '#markup_menu li', function(event) {
 


### PR DESCRIPTION
In Chrome, validation is done before CodeMirror rewrite its content to #id_raw. CodeMirror make it hidden, and Chrome prevent submitting because can't validate hidden empty textarea