### PR TITLE
Make Waliki compatible with Django 2.0

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -42,6 +42,14 @@ try:
                 },
             },
         ],
+        MIDDLEWARE=(
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+            'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        ),
         MIDDLEWARE_CLASSES=(
             'django.contrib.sessions.middleware.SessionMiddleware',
             'django.middleware.common.CommonMiddleware',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,8 +3,12 @@ import os
 import shutil
 from sh import git
 from mock import patch, PropertyMock
+from django import VERSION
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from waliki.models import Page
 from waliki.git.models import Git
 from waliki.settings import WALIKI_DATA_DIR, WALIKI_COMMITTER_EMAIL, WALIKI_COMMITTER_NAME

--- a/tests/test_git_webhook.py
+++ b/tests/test_git_webhook.py
@@ -1,5 +1,9 @@
+from django import VERSION
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from .factories import PageFactory
 from waliki.settings import WALIKI_DATA_DIR
 from waliki.models import Page

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,5 +1,9 @@
+from django import VERSION
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from .factories import PageFactory, RedirectFactory
 
 

--- a/tests/test_slides.py
+++ b/tests/test_slides.py
@@ -2,9 +2,13 @@ import json
 import os
 import mock
 import unittest
+from django import VERSION
 from django.test import TestCase
 from waliki.models import Page
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.template.loader import render_to_string
 from waliki import settings

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,13 @@
 import json
 import os
 import mock
+from django import VERSION
 from django.test import TestCase
 from waliki.models import Page
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django import forms
 from waliki.models import Redirect

--- a/waliki/acl.py
+++ b/waliki/acl.py
@@ -9,6 +9,7 @@ from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.six import string_types
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.shortcuts import resolve_url
+from waliki.utils import is_authenticated
 from .models import ACLRule
 from .settings import (WALIKI_ANONYMOUS_USER_PERMISSIONS,
                        WALIKI_LOGGED_USER_PERMISSIONS,
@@ -31,7 +32,7 @@ def check_perms(perms, user, slug, raise_exception=False):
     if perms.issubset(set(WALIKI_ANONYMOUS_USER_PERMISSIONS)):
         return True
 
-    if user.is_authenticated() and perms.issubset(set(WALIKI_LOGGED_USER_PERMISSIONS)):
+    if is_authenticated(user) and perms.issubset(set(WALIKI_LOGGED_USER_PERMISSIONS)):
         return True
 
     # First check if the user has the permission (even anon users)
@@ -61,7 +62,7 @@ def permission_required(perms, login_url=None, raise_exception=False, redirect_f
 
             if check_perms(perms, request.user, kwargs['slug'], raise_exception=raise_exception):
                 return view_func(request, *args, **kwargs)
-            if request.user.is_authenticated():
+            if is_authenticated(request.user):
                 if WALIKI_RENDER_403:
                     return render(request, 'waliki/403.html', kwargs, status=403)
                 else:

--- a/waliki/attachments/migrations/0001_initial.py
+++ b/waliki/attachments/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(serialize=False, verbose_name='ID', primary_key=True, auto_created=True)),
                 ('file', models.FileField(upload_to=waliki.settings.WALIKI_UPLOAD_TO)),
-                ('page', models.ForeignKey(related_name='attachments', to='waliki.Page')),
+                ('page', models.ForeignKey(related_name='attachments', to='waliki.Page', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'Attachment',

--- a/waliki/attachments/models.py
+++ b/waliki/attachments/models.py
@@ -1,19 +1,25 @@
 # -*- coding: utf-8 -*-
 import os.path
+from django import VERSION
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.db.models.signals import pre_delete
 from django.dispatch.dispatcher import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.six import text_type
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from waliki.models import Page
 from waliki.settings import WALIKI_UPLOAD_TO
 
 
 @python_2_unicode_compatible
 class Attachment(models.Model):
-    page = models.ForeignKey(Page, related_name='attachments')
+    page = models.ForeignKey(Page,
+                             on_delete=models.CASCADE,
+                             related_name='attachments')
     file = models.FileField(upload_to=WALIKI_UPLOAD_TO, max_length=300)
 
     class Meta:

--- a/waliki/git/models.py
+++ b/waliki/git/models.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from waliki.signals import page_saved, page_preedit, page_moved
 from waliki import settings
 from waliki.models import Page
+from waliki.utils import is_authenticated
 
 
 git = git.bake("--no-pager", _tty_out=False)
@@ -40,7 +41,7 @@ class Git(object):
             paths_to_commit.append(extra_path)
         kwargs = {}
         User = get_user_model()
-        if isinstance(author, User) and author.is_authenticated():
+        if isinstance(author, User) and is_authenticated(author):
             kwargs['author'] = u"%s <%s>" % (author.get_full_name() or author.username, author.email)
         elif isinstance(author, six.string_types):
             kwargs['author'] = author

--- a/waliki/git/views.py
+++ b/waliki/git/views.py
@@ -2,13 +2,17 @@ import json
 from django.utils import timezone
 
 from datetime import datetime
+from django import VERSION
 from django.templatetags.tz import localtime
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils.translation import ugettext_lazy as _
 from django.http import Http404
 from django.core.management import call_command
 from django.http import HttpResponse
-from django.core.urlresolvers import reverse, reverse_lazy
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse, reverse_lazy
+else:
+    from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.encoding import smart_text
 from django.utils.six import StringIO, text_type
 from django.views.decorators.csrf import csrf_exempt

--- a/waliki/models.py
+++ b/waliki/models.py
@@ -3,11 +3,15 @@ import os
 import codecs
 import shutil
 import os.path
+from django import VERSION
 from django.db import models
 from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.conf import settings
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.dispatch import receiver
 from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _

--- a/waliki/search/views.py
+++ b/waliki/search/views.py
@@ -6,11 +6,13 @@ from django.contrib.auth.decorators import user_passes_test
 
 from django.conf import settings
 
+from waliki.utils import is_authenticated
+
 def user_has_permission(user):
     if 'view_page' in settings.WALIKI_ANONYMOUS_USER_PERMISSIONS:
         return True
 
-    if user.is_authenticated() and user.is_active:
+    if is_authenticated(user) and user.is_active:
         return True
 
     return False

--- a/waliki/templatetags/waliki_tags.py
+++ b/waliki/templatetags/waliki_tags.py
@@ -1,5 +1,9 @@
+from django import VERSION
 from django import template
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from waliki.acl import check_perms as check_perms_helper
 from waliki.models import Page

--- a/waliki/utils.py
+++ b/waliki/utils.py
@@ -2,8 +2,12 @@ import os
 import re
 import mimetypes
 import unicodedata
+from django import VERSION
 from django.http import HttpResponse
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.utils.six import PY2
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
@@ -49,3 +53,10 @@ def send_file(path, filename=None, content_type=None):
     response['Content-Disposition'] = 'attachment; filename=%s' % filename
     response.write(open(path, "rb").read())
     return response
+
+if VERSION[:2] >= (1, 10):
+    def is_authenticated(user):
+        return user.is_authenticated
+else:
+    def is_authenticated(user):
+        return user.is_authenticated()

--- a/waliki/views.py
+++ b/waliki/views.py
@@ -1,11 +1,15 @@
 import json
+from django import VERSION
 from django.http import HttpResponse, Http404, HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import render, redirect, get_object_or_404
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from .models import Page, Redirect
 from .forms import PageForm, MovePageForm, DeleteForm, NewPageForm
 from .signals import page_saved, page_preedit, page_moved


### PR DESCRIPTION
The following compatibility issues have been fixed:
* new style middleware configuration using `MIDDLEWARE` settings key;
* using `django.urls` instead of `django.core.urlresolvers` package;
* `is_authenticated` is now property of `User`, not method;
* `on_delete` parameter is mandatory for `ForeignKey` model.

Also, project has been marked as Django 2.0 compatible in `setup.py` file.