### PR TITLE
Add test with Django 2.0.5 to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO=1.9.12
   - DJANGO=1.10.6
   - DJANGO=1.11rc1
+  - DJANGO=2.0.5
 
 matrix:
   include:


### PR DESCRIPTION
This change just adds test with Django 2.0.5 to Travis configuration.