### PR TITLE
docs: Fix simple typo, folowed -> followed

### DIFF
--- a/waliki/static/codemirror/mode/django/django.js
+++ b/waliki/static/codemirror/mode/django/django.js
@@ -98,7 +98,7 @@
           return "null";
         }
 
-        // Dot folowed by a non-word character should be considered an error.
+        // Dot followed by a non-word character should be considered an error.
         if (stream.match(/\.\W+/)) {
           return "error";
         } else if (stream.eat(".")) {
@@ -117,7 +117,7 @@
           return "null";
         }
 
-        // Pipe folowed by a non-word character should be considered an error.
+        // Pipe followed by a non-word character should be considered an error.
         if (stream.match(/\.\W+/)) {
           return "error";
         } else if (stream.eat("|")) {
@@ -197,7 +197,7 @@
           return "null";
         }
 
-        // Dot folowed by a non-word character should be considered an error.
+        // Dot followed by a non-word character should be considered an error.
         if (stream.match(/\.\W+/)) {
           return "error";
         } else if (stream.eat(".")) {
@@ -216,7 +216,7 @@
           return "null";
         }
 
-        // Pipe folowed by a non-word character should be considered an error.
+        // Pipe followed by a non-word character should be considered an error.
         if (stream.match(/\.\W+/)) {
           return "error";
         } else if (stream.eat("|")) {


### PR DESCRIPTION
There is a small typo in waliki/static/codemirror/mode/django/django.js.

Should read `followed` rather than `folowed`.

